### PR TITLE
Re-routed more buttons in the frontend, added admin/:id/load-images route 

### DIFF
--- a/frontend/aespa/src/app/admin-landing/admin-landing.component.html
+++ b/frontend/aespa/src/app/admin-landing/admin-landing.component.html
@@ -38,7 +38,7 @@
               <i class="bi bi-three-dots-vertical kebab"></i>
             </a>
             <ul class="dropdown-menu">
-              <li><a class="dropdown-item">Update Tags</a></li>
+              <li><a class="dropdown-item" (click)="onLoadImages(album)">Update Tags</a></li>
               <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#deleteModal" (click)="onDelete(album)">Delete</a></li>
             </ul>
           </div>

--- a/frontend/aespa/src/app/admin-landing/admin-landing.component.ts
+++ b/frontend/aespa/src/app/admin-landing/admin-landing.component.ts
@@ -5,8 +5,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-admin-landing',
   templateUrl: './admin-landing.component.html',
-  styleUrls: ['./admin-landing.component.css'],
-  
+  styleUrls: ['./admin-landing.component.css']
 })
 
 export class AdminLandingComponent {
@@ -55,6 +54,12 @@ export class AdminLandingComponent {
   onAddGuest() {
     this.router.navigate(['../register-guest']);
   }
+
+  onLoadImages(album: any) {
+    const id = album.id;
+    this.router.navigate([`/admin/${id}/load-images`]);
+  }
+  
 }
 
 

--- a/frontend/aespa/src/app/app-routing.module.ts
+++ b/frontend/aespa/src/app/app-routing.module.ts
@@ -18,7 +18,7 @@ const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'admin', component: AdminLandingComponent },
   { path: 'admin/upload', component: UploadComponent },
-  { path: 'admin/load-images', component: LoadImagesComponent },
+  { path: 'admin/:id/load-images', component: LoadImagesComponent },
   { path: 'guest/load-images', component: GuestLoadImagesComponent },
   { path: 'guest', component: GuestLandingComponent },
   { path: 'guest/view', component: ViewImagesComponent },

--- a/frontend/aespa/src/app/guest-load-images/guest-load-images.component.css
+++ b/frontend/aespa/src/app/guest-load-images/guest-load-images.component.css
@@ -1,3 +1,6 @@
 .box-shadow {
   box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
+.selectForm {
+  width: 100%;
+}

--- a/frontend/aespa/src/app/guest-load-images/guest-load-images.component.html
+++ b/frontend/aespa/src/app/guest-load-images/guest-load-images.component.html
@@ -3,6 +3,8 @@
     <div class="container-xl">
  <!-- Beginning OF TAGs Dropdown -->
       <div class="row mb-3">
+        <div class="d-flex">
+        <div class="p-2 flex-grow-1">
         <form [formGroup]="heroForm">
           <div class="form-group">
             <ng-select
@@ -74,6 +76,11 @@
             </ng-select>
           </div>
         </form>
+      </div>
+      <div class="p-2">
+       <button type="button" class="btn btn-primary" (click)="onDone()">Done</button>
+      </div> 
+      </div>      
       </div>
  <!-- End OF TAGs Dropdown -->
 

--- a/frontend/aespa/src/app/guest-load-images/guest-load-images.component.ts
+++ b/frontend/aespa/src/app/guest-load-images/guest-load-images.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewEncapsulation } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Image } from "./image";
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-load-images',
@@ -17,7 +18,7 @@ export class GuestLoadImagesComponent {
   getTagUrl = 'http://localhost:8827/tags/fetchTags';
   images: Image[] = [];
 
-  constructor(private http: HttpClient, private fb: FormBuilder) { }
+  constructor(private http: HttpClient, private fb: FormBuilder, private router: Router) { }
 
   ngOnInit() {
     this.getImages();
@@ -63,4 +64,8 @@ export class GuestLoadImagesComponent {
     this.tags = this.tags.concat({ id: term, name: term });
     return { id: term, name: term };
   };
+
+  onDone() {
+    this.router.navigate(['../guest/slideshow/']);
+  }
 }

--- a/frontend/aespa/src/app/load-images/load-images.component.html
+++ b/frontend/aespa/src/app/load-images/load-images.component.html
@@ -82,7 +82,7 @@
         <button (click)="addTags()" type="button" class="btn btn-success">Tag All Images</button>
       </div>
       <div class="p-2">
-       <button type="button" class="btn btn-primary">Done</button>
+       <button type="button" class="btn btn-primary" (click)="onDone()">Done</button>
       </div> 
       </div>      
       </div>

--- a/frontend/aespa/src/app/load-images/load-images.component.ts
+++ b/frontend/aespa/src/app/load-images/load-images.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewEncapsulation } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Image } from "./image";
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-load-images',
@@ -18,7 +19,7 @@ export class LoadImagesComponent {
   addTagUrl = 'http://localhost:8827/tags/addTags'
   images: Image[] = [];
 
-  constructor(private http: HttpClient, private fb: FormBuilder) { }
+  constructor(private http: HttpClient, private fb: FormBuilder, private router: Router) { }
 
   ngOnInit() {
     this.getImages();
@@ -82,4 +83,8 @@ addTags() {
     this.tags = this.tags.concat({ id: term, name: term });
     return { id: term, name: term };
   };
+
+  onDone() {
+    this.router.navigate(['../admin/']);
+  }
 }


### PR DESCRIPTION
What I have added in this commit:
- In the Admin Landing page, each **Update Tags** button, on each Album tile, goes to a new route called: admin/**:id**/load-images 
 - In the Admin Load Images Page, the **Done** button goes to the Admin Landing page
 - In the Guest Load images Page, the **Done** button goes to the Slideshow page

